### PR TITLE
feat: make text RTL compatible

### DIFF
--- a/content/docs/cards-simple.mdx
+++ b/content/docs/cards-simple.mdx
@@ -35,7 +35,7 @@ description:
 }
 const CardBody = ({ className = "p-4" }) => (
 
-  <div className={cn("text-left", className)}>
+  <div className={cn("text-start", className)}>
     <h3 className="text-lg font-bold mb-1 text-gray-900 dark:text-gray-100">
       {cardContent.title}
     </h3>
@@ -101,7 +101,7 @@ const cardContent = {
     "Lorem ipsum dolor, sit amet consectetur adipisicing elit. Nostrum, hic ipsum! Qui dicta debitis aliquid quo molestias explicabo iure!",
 }
 const CardBody = ({ className = "p-4" }) => (
-  <div className={cn("text-left", className)}>
+  <div className={cn("text-start", className)}>
     <h3 className="text-lg font-bold mb-1 text-gray-900 dark:text-gray-100">
       {cardContent.title}
     </h3>
@@ -159,7 +159,7 @@ const cardContent = {
     "Lorem ipsum dolor, sit amet consectetur adipisicing elit. Nostrum, hic ipsum! Qui dicta debitis aliquid quo molestias explicabo iure!",
 }
 const CardBody = ({ className = "p-4" }) => (
-  <div className={cn("text-left", className)}>
+  <div className={cn("text-start", className)}>
     <h3 className="text-lg font-bold mb-1 text-gray-900 dark:text-gray-100">
       {cardContent.title}
     </h3>
@@ -220,7 +220,7 @@ const cardContent = {
     "Lorem ipsum dolor, sit amet consectetur adipisicing elit. Nostrum, hic ipsum! Qui dicta debitis aliquid quo molestias explicabo iure!",
 }
 const CardBody = ({ className = "p-4" }) => (
-  <div className={cn("text-left", className)}>
+  <div className={cn("text-start", className)}>
     <h3 className="text-lg font-bold mb-1 text-gray-900 dark:text-gray-100">
       {cardContent.title}
     </h3>
@@ -259,7 +259,7 @@ const cardContent = {
     "Lorem ipsum dolor, sit amet consectetur adipisicing elit. Nostrum, hic ipsum! Qui dicta debitis aliquid quo molestias explicabo iure!",
 }
 const CardBody = ({ className = "p-4" }) => (
-  <div className={cn("text-left", className)}>
+  <div className={cn("text-start", className)}>
     <h3 className="text-lg mb-1 font-bold text-gray-900 dark:text-gray-100">
       {cardContent.title}
     </h3>
@@ -310,7 +310,7 @@ const cardContent = {
     "Lorem ipsum dolor, sit amet consectetur adipisicing elit. Nostrum, hic ipsum! Qui dicta debitis aliquid quo molestias explicabo iure!",
 }
 const CardBody = ({ className = "p-4" }) => (
-  <div className={cn("text-left", className)}>
+  <div className={cn("text-start", className)}>
     <h3 className="text-lg mb-1 font-bold text-gray-900 dark:text-gray-100">
       {cardContent.title}
     </h3>

--- a/content/docs/cards-with-image-bg.mdx
+++ b/content/docs/cards-with-image-bg.mdx
@@ -32,7 +32,7 @@ const cardContent = {
 const CardBody = ({ className = "" }) => (
   <div
     className={cn(
-      "px-2 text-gray-100 sm:px-4 py-0 sm:pb-3 text-left",
+      "px-2 text-gray-100 sm:px-4 py-0 sm:pb-3 text-start",
       className
     )}
   >
@@ -139,7 +139,7 @@ const cardContent = {
 const CardBody = ({ className = "" }) => (
   <div
     className={cn(
-      "px-2 text-gray-100 sm:px-4 py-0 sm:pb-3 text-left",
+      "px-2 text-gray-100 sm:px-4 py-0 sm:pb-3 text-start",
       className
     )}
   >
@@ -198,7 +198,7 @@ const cardContent = {
 const CardBody = ({ className = "" }) => (
   <div
     className={cn(
-      "px-2 text-gray-100 sm:px-4 py-0 sm:pb-3 text-left",
+      "px-2 text-gray-100 sm:px-4 py-0 sm:pb-3 text-start",
       className
     )}
   >
@@ -257,7 +257,7 @@ const cardContent = {
 const CardBody = ({ className = "" }) => (
   <div
     className={cn(
-      "px-2 text-gray-100 sm:px-4 py-0 sm:pb-3 text-left",
+      "px-2 text-gray-100 sm:px-4 py-0 sm:pb-3 text-start",
       className
     )}
   >
@@ -316,7 +316,7 @@ const cardContent = {
 const CardBody = ({ className = "" }) => (
   <div
     className={cn(
-      "px-2 text-gray-100 sm:px-4 py-0 sm:pb-3 text-left",
+      "px-2 text-gray-100 sm:px-4 py-0 sm:pb-3 text-start",
       className
     )}
   >

--- a/content/docs/cards-with-pattern.mdx
+++ b/content/docs/cards-with-pattern.mdx
@@ -46,7 +46,7 @@ const cardContent = {
     'Lorem ipsum dolor, sit amet elit consectetur adipisicing. Nostrum, hic ipsum! dolor, sit amet elit consectetur amete elite!',
 };
 export const CardBody = ({ className = '' }) => (
-  <div className={cn('text-left p-4 md:p-6', className)}>
+  <div className={cn('text-start p-4 md:p-6', className)}>
     <h3 className="text-lg font-bold mb-1 text-zinc-200">
       {cardContent.title}
     </h3>
@@ -95,7 +95,7 @@ const cardContent = {
     'Lorem ipsum dolor, sit amet elit consectetur adipisicing. Nostrum, hic ipsum! dolor, sit amet elit consectetur amete elite!',
 };
 export const CardBody = ({ className = '' }) => (
-  <div className={cn('text-left p-4 md:p-6', className)}>
+  <div className={cn('text-start p-4 md:p-6', className)}>
     <h3 className="text-lg font-bold mb-1 text-zinc-200">
       {cardContent.title}
     </h3>
@@ -136,7 +136,7 @@ const cardContent = {
     'Lorem ipsum dolor, sit amet elit consectetur adipisicing. Nostrum, hic ipsum! dolor, sit amet elit consectetur amete elite!',
 };
 export const CardBody = ({ className = '' }) => (
-  <div className={cn('text-left p-4 md:p-6', className)}>
+  <div className={cn('text-start p-4 md:p-6', className)}>
     <h3 className="text-lg font-bold mb-1 text-zinc-200">
       {cardContent.title}
     </h3>
@@ -179,7 +179,7 @@ const cardContent = {
     'Lorem ipsum dolor, sit amet elit consectetur adipisicing. Nostrum, hic ipsum! dolor, sit amet elit consectetur amete elite!',
 };
 export const CardBody = ({ className = '' }) => (
-  <div className={cn('text-left p-4 md:p-6', className)}>
+  <div className={cn('text-start p-4 md:p-6', className)}>
     <h3 className="text-lg font-bold mb-1 text-zinc-200">
       {cardContent.title}
     </h3>
@@ -224,7 +224,7 @@ const cardContent = {
     'Lorem ipsum dolor, sit amet elit consectetur adipisicing. Nostrum, hic ipsum! dolor, sit amet elit consectetur amete elite!',
 };
 export const CardBody = ({ className = '' }) => (
-  <div className={cn('text-left p-4 md:p-6', className)}>
+  <div className={cn('text-start p-4 md:p-6', className)}>
     <h3 className="text-lg font-bold mb-1 text-zinc-200">
       {cardContent.title}
     </h3>
@@ -265,7 +265,7 @@ const cardContent = {
     'Lorem ipsum dolor, sit amet elit consectetur adipisicing. Nostrum, hic ipsum! dolor, sit amet elit consectetur amete elite!',
 };
 export const CardBody = ({ className = '' }) => (
-  <div className={cn('text-left p-4 md:p-6', className)}>
+  <div className={cn('text-start p-4 md:p-6', className)}>
     <h3 className="text-lg font-bold mb-1 text-zinc-200">
       {cardContent.title}
     </h3>
@@ -305,7 +305,7 @@ const cardContent = {
     'Lorem ipsum dolor, sit amet elit consectetur adipisicing. Nostrum, hic ipsum! dolor, sit amet elit consectetur amete elite!',
 };
 export const CardBody = ({ className = '' }) => (
-  <div className={cn('text-left p-4 md:p-6', className)}>
+  <div className={cn('text-start p-4 md:p-6', className)}>
     <h3 className="text-lg font-bold mb-1 text-zinc-200">
       {cardContent.title}
     </h3>
@@ -346,7 +346,7 @@ const cardContent = {
     'Lorem ipsum dolor, sit amet elit consectetur adipisicing. Nostrum, hic ipsum! dolor, sit amet elit consectetur amete elite!',
 };
 export const CardBody = ({ className = '' }) => (
-  <div className={cn('text-left p-4 md:p-6', className)}>
+  <div className={cn('text-start p-4 md:p-6', className)}>
     <h3 className="text-lg font-bold mb-1 text-zinc-200">
       {cardContent.title}
     </h3>

--- a/src/components/cards/simple-cards.tsx
+++ b/src/components/cards/simple-cards.tsx
@@ -6,7 +6,7 @@ const cardContent = {
     'Lorem ipsum dolor, sit amet consectetur adipisicing elit. Nostrum, hic ipsum! Qui dicta debitis aliquid quo molestias explicabo iure!',
 };
 const CardBody = ({ className = 'p-4' }) => (
-  <div className={cn('text-left', className)}>
+  <div className={cn('text-start', className)}>
     <h3 className="text-lg font-bold mb-1 text-gray-900 dark:text-gray-100">
       {cardContent.title}
     </h3>

--- a/src/components/cards/with-image-bg.tsx
+++ b/src/components/cards/with-image-bg.tsx
@@ -11,7 +11,7 @@ const cardContent = {
 const CardBody = ({ className = '' }) => (
   <div
     className={cn(
-      'px-2 text-gray-100 sm:px-4 py-0 sm:pb-3 text-left',
+      'px-2 text-gray-100 sm:px-4 py-0 sm:pb-3 text-start',
       className,
     )}
   >

--- a/src/components/cards/with-pattern.tsx
+++ b/src/components/cards/with-pattern.tsx
@@ -6,7 +6,7 @@ const cardContent = {
     'Lorem ipsum dolor, sit amet elit consectetur adipisicing. Nostrum, hic ipsum! dolor, sit amet elit consectetur amete elite!',
 };
 export const CardBody = ({ className = '' }) => (
-  <div className={cn('text-left p-4 md:p-6', className)}>
+  <div className={cn('text-start p-4 md:p-6', className)}>
     <h3 className="text-lg font-bold mb-1 text-zinc-200">
       {cardContent.title}
     </h3>

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -28,7 +28,7 @@ const AccordionTrigger = React.forwardRef<
     <AccordionPrimitive.Trigger
       ref={ref}
       className={cn(
-        'flex flex-1 items-center justify-between py-4 text-sm font-medium transition-all hover:underline text-left [&[data-state=open]>svg]:rotate-180',
+        'flex flex-1 items-center justify-between py-4 text-sm font-medium transition-all hover:underline text-start [&[data-state=open]>svg]:rotate-180',
         className,
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -57,7 +57,7 @@ const DialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      'flex flex-col space-y-1.5 text-center sm:text-left',
+      'flex flex-col space-y-1.5 text-center sm:text-start',
       className,
     )}
     {...props}

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -58,7 +58,7 @@ const DrawerHeader = ({
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn('grid gap-1.5 p-4 text-center sm:text-left', className)}
+    className={cn('grid gap-1.5 p-4 text-center sm:text-start', className)}
     {...props}
   />
 );

--- a/src/components/variants-card.tsx
+++ b/src/components/variants-card.tsx
@@ -18,7 +18,7 @@ export const VariantsCard = ({
     className="border px-2 sm:px-4 md:px-8 pb-6 pt-3 border-dashed rounded-lg shadow bg-white dark:bg-black"
   >
     <div className="flex-row-between mb-4 gap-1 border-b border-dashed py-1">
-      <h3 className="text-xl font-bold text-left">{title}</h3>
+      <h3 className="text-xl font-bold text-start">{title}</h3>
       <Button asChild variant="ghost" size="sm" rightIcon={<FaChevronRight />}>
         <Link href={docUrl} prefetch={false}>
           Get code

--- a/src/form-builder/components/code-viewer.tsx
+++ b/src/form-builder/components/code-viewer.tsx
@@ -121,7 +121,7 @@ export function InstallPackagesCode() {
 
   return (
     <div className="w-full py-5 max-w-full">
-      <h2 className="font-sembold text-left">Install base packages</h2>
+      <h2 className="font-sembold text-start">Install base packages</h2>
       <Tabs
         items={tabsData.map((o) => o.value)}
         className="w-full mt-2 rounded-md"
@@ -134,7 +134,7 @@ export function InstallPackagesCode() {
           </Tab>
         ))}
       </Tabs>
-      <h2 className="font-sembold text-left mt-4">
+      <h2 className="font-sembold text-start mt-4">
         Install required shadcn components
       </h2>
       <Tabs

--- a/src/form-builder/components/field-customization-view.tsx
+++ b/src/form-builder/components/field-customization-view.tsx
@@ -286,7 +286,7 @@ export function FieldCustomizationView({
         </Button>
       </DrawerTrigger>
       <DrawerContent>
-        <DrawerHeader className="text-left">
+        <DrawerHeader className="text-start">
           <DrawerTitle>{title}</DrawerTitle>
         </DrawerHeader>
         <SavedFormElementOptions />

--- a/src/form-builder/components/render-form-element.tsx
+++ b/src/form-builder/components/render-form-element.tsx
@@ -447,7 +447,7 @@ export const RenderFormElement = ({
                       <Button
                         variant={'outline'}
                         className={cn(
-                          'w-full justify-start text-left font-normal',
+                          'w-full justify-start text-start font-normal',
                           !date && 'text-muted-foreground',
                         )}
                       >

--- a/src/form-builder/libs/generate-form-component.ts
+++ b/src/form-builder/libs/generate-form-component.ts
@@ -136,7 +136,7 @@ export const getFormElementCode = (field: FormElement) => {
                 <Button
                   variant={"outline"}
                   className={cn(
-                    "w-[240px] pl-3 text-left font-normal",
+                    "w-[240px] pl-3 text-start font-normal",
                     !field.value && "text-muted-foreground"
                   )}
                 >


### PR DESCRIPTION
This PR simply replaces all instances of `text-left` with `text-start` so that whenever the direction is RTL it will flip as expected.